### PR TITLE
OP execution client as global env

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -36,7 +36,7 @@
   },
   "globalEnvs": [
     {
-      "envs": ["EXECUTION_CLIENT_MAINNET"],
+      "envs": ["EXECUTION_CLIENT_MAINNET", "OP_EXECUTION_CLIENT"],
       "services": ["op-node"]
     }
   ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,5 @@ services:
       context: op-node
       args:
         UPSTREAM_VERSION: v1.1.3
-    environment:
-      L2_CLIENT: op-geth.dnp.dappnode.eth
-      USER_JWT: ""
     restart: unless-stopped
+    image: "op-node.op-node.dnp.dappnode.eth:0.1.0"

--- a/op-node/entrypoint.sh
+++ b/op-node/entrypoint.sh
@@ -19,7 +19,7 @@ case $_DAPPNODE_GLOBAL_EXECUTION_CLIENT_MAINNET in
   ;;
 esac
 
-case $L2_CLIENT in
+case $_DAPPNODE_GLOBAL_OP_EXECUTION_CLIENT in
 "op-geth.dnp.dappnode.eth")
   L2_ENGINE="http://op-geth.dappnode:8551"
   JWT_PATH="/security/op-geth/jwtsecret.hex"
@@ -29,11 +29,9 @@ case $L2_CLIENT in
   JWT_PATH="/security/op-erigon/jwtsecret.hex"
   ;;
 *)
-  echo "Unknown value for L2_CLIENT: $L2_CLIENT"
-  L2_ENGINE=$L2_CLIENT
-  mkdir -p /config/security/user
-  echo $USER_JWT >/security/user/jwtsecret.hex
-  JWT_PATH="/security/user/jwtsecret.hex"
+  echo "Unknown value for _DAPPNODE_GLOBAL_OP_EXECUTION_CLIENT: $_DAPPNODE_GLOBAL_OP_EXECUTION_CLIENT"
+  sleep 60
+  exit 1
   ;;
 esac
 


### PR DESCRIPTION
Execution client for OP is now treated as a global env