### PR TITLE
Feat: Add support for Optimistic Ecotone Mainnet Release - update to v1.7.1

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,7 +1,7 @@
 {
   "name": "op-node.dnp.dappnode.eth",
   "version": "0.1.1",
-  "upstreamVersion": "v1.4.2",
+  "upstreamVersion": "v1.7.1",
   "upstreamRepo": "ethereum-optimism/optimism",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Optimism Rollup node",
@@ -36,7 +36,7 @@
   },
   "globalEnvs": [
     {
-      "envs": ["EXECUTION_CLIENT_MAINNET", "OP_EXECUTION_CLIENT"],
+      "envs": ["EXECUTION_CLIENT_MAINNET", "CONSENSUS_CLIENT_MAINNET","OP_EXECUTION_CLIENT"],
       "services": ["op-node"]
     }
   ]

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -1,6 +1,6 @@
 {
   "name": "op-node.dnp.dappnode.eth",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "upstreamVersion": "v1.7.1",
   "upstreamRepo": "ethereum-optimism/optimism",
   "upstreamArg": "UPSTREAM_VERSION",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,4 +9,4 @@ services:
       - CUSTOM_L1_RPC
       - CUSTOM_L1_BEACON_API
     restart: unless-stopped
-    image: "op-node.op-node.dnp.dappnode.eth:0.1.1"
+    image: "op-node.op-node.dnp.dappnode.eth:0.1.2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,9 @@ services:
     build:
       context: op-node
       args:
-        UPSTREAM_VERSION: v1.4.2
+        UPSTREAM_VERSION: v1.7.1
     environment:
       - CUSTOM_L1_RPC
+      - CUSTOM_L1_BEACON_API
     restart: unless-stopped
     image: "op-node.op-node.dnp.dappnode.eth:0.1.1"

--- a/op-node/entrypoint.sh
+++ b/op-node/entrypoint.sh
@@ -29,6 +29,39 @@ else
   exit 1
 fi
 
+# If CUSTOM_L1_BEACON_API is set, use it. Otherwise, use the proper value depending on the _DAPPNODE_GLOBAL_CONSENSUS_CLIENT_MAINNET variable
+
+if [ ! -z "$CUSTOM_L1_BEACON_API" ]; then
+  L1_BEACON_API=$CUSTOM_L1_BEACON_API
+elif [ ! -z "$_DAPPNODE_GLOBAL_CONSENSUS_CLIENT_MAINNET" ]; then
+  case $_DAPPNODE_GLOBAL_CONSENSUS_CLIENT_MAINNET in
+  "lodestar.dnp.dappnode.eth")
+    L1_BEACON_API="http://beacon-chain.lodestar.dappnode:3500"
+    ;;
+  "lighthouse.dnp.dappnode.eth")
+    L1_BEACON_API="http://beacon-chain.lighthouse.dappnode:3500"
+    ;;
+  "prysm.dnp.dappnode.eth")
+    L1_BEACON_API="http://beacon-chain.prysm.dappnode:3500"
+    ;;
+  "teku.dnp.dappnode.eth")
+    L1_BEACON_API="http://beacon-chain.teku.dappnode:3500"
+    ;;
+  "nimbus.dnp.dappnode.eth")
+    L1_BEACON_API="http://nimbus.dappnode:4500"
+    ;;
+  *)
+    echo "Unknown value for _DAPPNODE_GLOBAL_CONSENSUS_CLIENT_MAINNET: $_DAPPNODE_GLOBAL_CONSENSUS_CLIENT_MAINNET"
+    sleep 60
+    exit 1
+    ;;
+  esac
+else
+  echo "No L1_BEACON_API value set"
+  sleep 60
+  exit 1
+fi
+
 case $_DAPPNODE_GLOBAL_OP_EXECUTION_CLIENT in
 "op-geth.dnp.dappnode.eth")
   L2_ENGINE="http://op-geth.dappnode:8551"
@@ -48,6 +81,7 @@ esac
 while true; do
   op-node --network=op-mainnet \
     --l1="$L1_RPC" \
+    --l1.beacon="$L1_BEACON_API" \
     --l2="$L2_ENGINE" \
     --l2.jwt-secret="$JWT_PATH" \
     --rpc.addr=0.0.0.0 \


### PR DESCRIPTION
This PR aims at updating OP Node to its latest version as well as implement the needed dependency.
- upstream package is updated to [v1.7.1](https://github.com/ethereum-optimism/optimism/releases/tag/op-node%2Fv1.7.1)
- a new --l1.beacon flag is added, set to the consensus layer beacon API (using globalEnvs like it is done for L1 RPC)
- possibility to add a custom --l1.beacon using the CUSTOM_L1_BEACON_API variable (similar to L1 RPC too)